### PR TITLE
code: handle multi-line code segments with struct{} type

### DIFF
--- a/code/failpoint.go
+++ b/code/failpoint.go
@@ -55,6 +55,10 @@ func (fp *Failpoint) flush(dst io.Writer) error {
 func (fp *Failpoint) hdr(varname string) string {
 	hdr := fp.ws + "if v" + fp.name + ", __fpErr := " + fp.Runtime() + ".Acquire(); __fpErr == nil { "
 	hdr = hdr + "defer " + fp.Runtime() + ".Release(); "
+	if fp.varType == "struct{}" {
+		// unused
+		varname = "_"
+	}
 	return hdr + varname + ", __fpTypeOK := v" + fp.name +
 		".(" + fp.varType + "); if !__fpTypeOK { goto __badType" + fp.name + "} "
 }

--- a/code/failpoint.go
+++ b/code/failpoint.go
@@ -87,7 +87,7 @@ func (fp *Failpoint) flushMulti(dst io.Writer) error {
 		}
 	}
 	code := fp.code[len(fp.code)-1]
-	_, err := io.WriteString(dst, code[:len(code)-1]+fp.footer()+"\n")
+	_, err := io.WriteString(dst, code+fp.footer()+"\n")
 	return err
 }
 

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -41,6 +41,9 @@ func ToFailpoints(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) 
 		l, rerr := src.ReadString('\n')
 		if curfp != nil {
 			if strings.HasPrefix(strings.TrimSpace(l), "//") {
+				if len(l) > 0 && l[len(l)-1] == '\n' {
+					l = l[:len(l)-1]
+				}
 				curfp.code = append(curfp.code, strings.Replace(l, "//", "\t", 1))
 				continue
 			} else {

--- a/code/rewrite_test.go
+++ b/code/rewrite_test.go
@@ -33,6 +33,7 @@ var examples = []struct {
 	{"func f() {\n\t// gofail: var Test int\n\t// fmt.Println(Test)\n\n\t// gofail: var Test2 int\n\t// fmt.Println(Test2)\n}\n", 2},
 	{"func f() {\n\t// gofail: var NoTypeTest struct{}\n\t// fmt.Println(`hi`)\n}\n", 1},
 	{"func f() {\n\t// gofail: var NoTypeTest struct{}\n}\n", 1},
+	{"func f() {\n\t// gofail: var NoTypeTest struct{}\n\t// fmt.Println(`hi`)\n\t// fmt.Println(`bye`)\n}\n", 1},
 }
 
 func TestToFailpoint(t *testing.T) {

--- a/code/rewrite_test.go
+++ b/code/rewrite_test.go
@@ -31,6 +31,8 @@ var examples = []struct {
 	{"func f() {\n\t// gofail: var Test int\n\t// fmt.Println(Test)// return\n}\n", 1},
 	{"func f() {\n\t// gofail: var OneLineTest int\n}\n", 1},
 	{"func f() {\n\t// gofail: var Test int\n\t// fmt.Println(Test)\n\n\t// gofail: var Test2 int\n\t// fmt.Println(Test2)\n}\n", 2},
+	{"func f() {\n\t// gofail: var NoTypeTest struct{}\n\t// fmt.Println(`hi`)\n}\n", 1},
+	{"func f() {\n\t// gofail: var NoTypeTest struct{}\n}\n", 1},
 }
 
 func TestToFailpoint(t *testing.T) {
@@ -74,4 +76,3 @@ func TestToComment(t *testing.T) {
 	}
 
 }
-


### PR DESCRIPTION
found when trying to instrument raft.go to lose its leader