### PR TITLE
gofail.go: exit when 'enable/disable' is not specified

### DIFF
--- a/gofail.go
+++ b/gofail.go
@@ -160,6 +160,7 @@ func main() {
 		xfrm = code.ToComments
 	default:
 		fmt.Println("expected enable or disable")
+		os.Exit(1)
 	}
 
 	files := paths2files(os.Args[2:])


### PR DESCRIPTION
Otherwise 'gofail -h' panics.

@heyitsanthony 