### PR TITLE
*: support "continue" to label within for-loop

### DIFF
--- a/code/failpoint.go
+++ b/code/failpoint.go
@@ -60,7 +60,7 @@ func (fp *Failpoint) hdr(varname string) string {
 		varname = "_"
 	}
 	return hdr + varname + ", __fpTypeOK := v" + fp.name +
-		".(" + fp.varType + "); if !__fpTypeOK { goto __badType" + fp.name + "} "
+		".(" + fp.varType + "); if !__fpTypeOK { goto __badType" + fp.name + " } else { continue __fp_" + fp.name + " }"
 }
 
 func (fp *Failpoint) footer() string {
@@ -69,6 +69,10 @@ func (fp *Failpoint) footer() string {
 }
 
 func (fp *Failpoint) flushSingle(dst io.Writer) error {
+	if fp.varType == "continue" {
+		_, cerr := io.WriteString(dst, "__fp_"+fp.name+":\n")
+		return cerr
+	}
 	if _, err := io.WriteString(dst, fp.hdr("_")); err != nil {
 		return err
 	}

--- a/code/failpoint.go
+++ b/code/failpoint.go
@@ -27,6 +27,10 @@ type Failpoint struct {
 
 	// whitespace for padding
 	ws string
+
+	// if true, do not acquire read lock on failpoints
+	// useful for "continue"
+	eval bool
 }
 
 // newFailpoint makes a new failpoint based on the a line containing a
@@ -38,10 +42,11 @@ func newFailpoint(l string) (*Failpoint, error) {
 	}
 	cmd := strings.SplitAfter(l, "// gofail:")[1]
 	fields := strings.Fields(cmd)
-	if len(fields) != 3 || fields[0] != "var" {
+	if len(fields) < 3 || fields[0] != "var" {
 		return nil, fmt.Errorf("failpoint: malformed comment header %q", l)
 	}
-	return &Failpoint{name: fields[1], varType: fields[2], ws: strings.Split(l, "//")[0]}, nil
+	eval := len(fields) == 4 && fields[3] == "eval"
+	return &Failpoint{name: fields[1], varType: fields[2], ws: strings.Split(l, "//")[0], eval: eval}, nil
 }
 
 // flush writes the failpoint code to a buffer
@@ -53,8 +58,13 @@ func (fp *Failpoint) flush(dst io.Writer) error {
 }
 
 func (fp *Failpoint) hdr(varname string) string {
-	hdr := fp.ws + "if v" + fp.name + ", __fpErr := " + fp.Runtime() + ".Acquire(); __fpErr == nil { "
-	hdr = hdr + "defer " + fp.Runtime() + ".Release(); "
+	hdr := fp.ws + "if v" + fp.name + ", __fpErr := "
+	if !fp.eval {
+		hdr += fp.Runtime() + ".Acquire(); __fpErr == nil { "
+		hdr += "defer " + fp.Runtime() + ".Release(); "
+	} else {
+		hdr += fp.Runtime() + ".Eval(); __fpErr == nil { "
+	}
 	if fp.varType == "struct{}" {
 		// unused
 		varname = "_"

--- a/code/rewrite.go
+++ b/code/rewrite.go
@@ -108,6 +108,9 @@ func ToComments(wdst io.Writer, rsrc io.Reader) (fps []*Failpoint, err error) {
 			ws = strings.Split(l, "i")[0]
 			n := strings.Split(strings.Split(l, "__fp_")[1], ".")[0]
 			t := strings.Split(strings.Split(l, ".(")[1], ")")[0]
+			if strings.Contains(lTrim, n+"."+"Eval();") {
+				t += " eval"
+			}
 			dst.WriteString(ws + "// gofail: var " + n + " " + t + "\n")
 			if !strings.Contains(l, "; __badType") {
 				// not single liner

--- a/runtime/failpoint.go
+++ b/runtime/failpoint.go
@@ -30,6 +30,21 @@ func NewFailpoint(pkg, name string) *Failpoint {
 	return fp
 }
 
+// Eval merely evaluates the failpoint terms without
+// acquiring the read lock.
+func (fp *Failpoint) Eval() (interface{}, error) {
+	fp.mu.RLock()
+	defer fp.mu.RUnlock()
+	if fp.t == nil {
+		return nil, ErrDisabled
+	}
+	v, err := fp.t.eval()
+	if v == nil {
+		err = ErrDisabled
+	}
+	return v, err
+}
+
 // Acquire gets evalutes the failpoint terms; if the failpoint
 // is active, it will return a value. Otherwise, returns a non-nil error.
 func (fp *Failpoint) Acquire() (interface{}, error) {


### PR DESCRIPTION
Use case: I've been trying to integrate https://github.com/coreos/etcd/tree/master/tools/local-tester with our functional testing, by setting up a bridge between listen and advertise ports, to simulate network faults (e.g. drop all incoming packets to follower's advertise peer port to simulate an isolated follower).

However, the bridge layer cannot simulate outbound packet drops:

> sudo iptables -A INPUT -i ens4 -p tcp -m tcp --dport 2380 -j DROP && sudo iptables -A OUTPUT -o ens4 -p tcp -m tcp --dport 2380 -j DROP

It can only simulate append/snapshot message drops but not leader heartbeat drops (rafthttp creates an HTTP client to the leader's advertise peer port to poll leader heartbeats).

To summarize, we need `continue` support, to simulate leader heartbeat dropping (trying to extend it to test https://github.com/coreos/etcd/issues/9333 and https://github.com/coreos/etcd/issues/9563):

This PR adds a support for `"continue" + label`, as below:

```diff
diff --git a/rafthttp/stream.go b/rafthttp/stream.go
index 190504057..190118fd6 100644
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -510,6 +510,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
        }
        cr.mu.Unlock()
 
+       // gofail: var raftDropHeartbeat continue
        for {
                m, err := dec.decode()
                if err != nil {
@@ -519,6 +520,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
                        return err
                }
 
+               // gofail: var raftDropHeartbeat bool eval
                receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
```

`continue` failpoint must have matching `gofail` comments: one to define `continue` label, the other to define non-blocking `Eval` method call (since `defer` would block `DELETE` calls).

`gofail enable ./rafthttp` would output:

```diff
diff --git a/rafthttp/stream.go b/rafthttp/stream.go
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -510,7 +510,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
        }
        cr.mu.Unlock()
 
-       // gofail: var raftDropHeartbeat continue
+__fp_raftDropHeartbeat:
        for {
                m, err := dec.decode()
                if err != nil {
@@ -520,7 +520,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
                        return err
                }
 
-               // gofail: var raftDropHeartbeat bool eval
+               if vraftDropHeartbeat, __fpErr := __fp_raftDropHeartbeat.Eval(); __fpErr == nil { _, __fpTypeOK := vraftDropHeartbeat.(bool); if !__fpTypeOK { goto __badTyperaftDropHeartbeat } else { continue __fp_raftDropHeartbeat }; __badTyperaftDropHeartbeat: __fp_raftDropHeartbeat.BadType(vraftDropHeartbeat, "bool"); };
                receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
```

I tried it, and it seems to work well for our use case (`gofail disable ./rafthttp` works as well).

Any thoughts or better way? @heyitsanthony

Thanks!